### PR TITLE
Supporto ai negozi di vicinato

### DIFF
--- a/regolamento.md
+++ b/regolamento.md
@@ -8,6 +8,8 @@ Se gli argomenti proposti non saranno ritenuti pertinenti in alcun modo, verrann
 
 NON è gradita la pubblicità per attività commerciali private; ci sono altri gruppi appositamente creati a tale scopo.
 
+Al solo scopo di promuovere i negozi di vicinato, è concesso e anzi incoraggiato 1 (un) solo primo post di presentazione di nuove attività, che dovrà solo avere un carattere di presentazione contenente indicativamente il nome dell'attività e/o dei titolari, la categoria e il luogo e che deve necessariamente essere privo di riferimenti a offerte e prezzi.
+
 La discussione su ogni argomento (NB: anche politico) dovrà mantenersi nei toni e modi adeguati e rispettosi; nel momento in cui ciò verrà a mancare, si provvederà a rimuovere il post.
 
 Se una persona dovesse eccedere con comportamenti offensivi e poco opportuni gli amministratori avranno il dovere di cancellarne i commenti quindi, nel caso si ripeta, di bloccare l'utente per un certo tempo. Dopodiché, l'utente sarà reinserito, ma alla seconda segnalazione sarà bannato definitivamente.


### PR DESCRIPTION
Propongo un'integrazione al regolamento atta al supporto dei negozi di vicinato.
Questa proposta preserva il vincolo dell'assenza di pubblicità.
È nata in seguito all'esperienza con il [post di Ivana del Plato](https://www.facebook.com/groups/823777737638221/permalink/1861866427162675/):
<img width="494" alt="screen shot 2017-06-07 at 11 31 18" src="https://user-images.githubusercontent.com/21038/26871845-da931c7c-4b74-11e7-8574-6e860e966ca3.png">

